### PR TITLE
Add UI feedback during score sheet processing

### DIFF
--- a/MLScoreSheetCounter/MainPage.xaml
+++ b/MLScoreSheetCounter/MainPage.xaml
@@ -4,8 +4,8 @@
              x:Class="MLScoreSheetCounter.MainPage">
     
     <VerticalStackLayout Padding="16" Spacing="12">
-        <Button Text="Vybrat fotku z galerie" Clicked="OnPickPhoto"/>
-        <Button Text="Vyfotit" Clicked="OnTakePhoto"/>
+        <Button x:Name="PickPhotoButton" Text="Vybrat fotku z galerie" Clicked="OnPickPhoto"/>
+        <Button x:Name="TakePhotoButton" Text="Vyfotit" Clicked="OnTakePhoto"/>
 
         <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
             <CheckBox x:Name="OverlayCheckBox" IsChecked="True"/>
@@ -13,6 +13,11 @@
         </HorizontalStackLayout>
 
         <Label x:Name="ResultLabel" Text="TOTAL = ?" FontSize="18" />
+
+        <HorizontalStackLayout x:Name="ProcessingContainer" IsVisible="False" Spacing="8" VerticalOptions="Center">
+            <ActivityIndicator x:Name="ProcessingIndicator" IsRunning="False" VerticalOptions="Center"/>
+            <Label x:Name="ProcessingLabel" Text="Probíhá zpracování..." VerticalTextAlignment="Center"/>
+        </HorizontalStackLayout>
 
         <Image x:Name="Preview" Aspect="AspectFit" HeightRequest="380" />
     </VerticalStackLayout>

--- a/MLScoreSheetCounter/MainPage.xaml.cs
+++ b/MLScoreSheetCounter/MainPage.xaml.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using SkiaSharp;
 using YourApp.Services;
@@ -9,6 +10,19 @@ public partial class MainPage : ContentPage
     public MainPage()
     {
         InitializeComponent();
+    }
+
+    private void SetProcessingState(bool isProcessing)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            ProcessingContainer.IsVisible = isProcessing;
+            ProcessingIndicator.IsRunning = isProcessing;
+            ProcessingLabel.IsVisible = isProcessing;
+            PickPhotoButton.IsEnabled = !isProcessing;
+            TakePhotoButton.IsEnabled = !isProcessing;
+            OverlayCheckBox.IsEnabled = !isProcessing;
+        });
     }
 
     private async void OnPickPhoto(object sender, EventArgs e)
@@ -82,6 +96,7 @@ public partial class MainPage : ContentPage
 
     private async Task RunDetection(string photoPath)
     {
+        SetProcessingState(true);
         try
         {
             var showOverlay = OverlayCheckBox?.IsChecked ?? false;
@@ -121,6 +136,10 @@ public partial class MainPage : ContentPage
         catch (Exception ex)
         {
             await DisplayAlert("Chyba", ex.Message, "OK");
+        }
+        finally
+        {
+            SetProcessingState(false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add buttons and processing UI elements to main page to show a progress state during image analysis
- disable user interactions while processing to prevent duplicate requests
- centralize toggling of the processing indicator from code-behind

## Testing
- `dotnet build MLScoreSheetCounter/MLScoreSheetCounter.csproj` *(fails: dotnet not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e4558f08832ca0dc509c252d000b