### PR TITLE
Fix Android gallery saver context retrieval

### DIFF
--- a/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
+++ b/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
@@ -1,0 +1,154 @@
+using System;
+using Microsoft.Maui.Controls;
+
+namespace MLScoreSheetCounter.Controls;
+
+public class PinchToZoomContainer : ContentView
+{
+    private double _currentScale = 1;
+    private double _startScale = 1;
+    private double _xOffset;
+    private double _yOffset;
+
+    public PinchToZoomContainer()
+    {
+        var pinch = new PinchGestureRecognizer();
+        pinch.PinchUpdated += OnPinchUpdated;
+        GestureRecognizers.Add(pinch);
+
+        var pan = new PanGestureRecognizer();
+        pan.PanUpdated += OnPanUpdated;
+        GestureRecognizers.Add(pan);
+
+        var doubleTap = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
+        doubleTap.Tapped += (_, _) => Reset();
+        GestureRecognizers.Add(doubleTap);
+    }
+
+    public void Reset()
+    {
+        _currentScale = 1;
+        _startScale = 1;
+        _xOffset = 0;
+        _yOffset = 0;
+
+        if (Content != null)
+        {
+            Content.AnchorX = 0.5;
+            Content.AnchorY = 0.5;
+            Content.Scale = 1;
+            Content.TranslationX = 0;
+            Content.TranslationY = 0;
+        }
+    }
+
+    private void OnPinchUpdated(object? sender, PinchGestureUpdatedEventArgs e)
+    {
+        if (Content == null)
+        {
+            return;
+        }
+
+        switch (e.Status)
+        {
+            case GestureStatus.Started:
+                _startScale = Content.Scale;
+                Content.AnchorX = 0;
+                Content.AnchorY = 0;
+                break;
+            case GestureStatus.Running:
+                var targetScale = Math.Clamp(_startScale * e.Scale, 1, 6);
+
+                var renderedX = Content.X + _xOffset;
+                var deltaX = renderedX / Width;
+                var deltaWidth = Width / (Content.Width * _startScale);
+                var originX = (e.ScaleOrigin.X - deltaX) * deltaWidth;
+
+                var renderedY = Content.Y + _yOffset;
+                var deltaY = renderedY / Height;
+                var deltaHeight = Height / (Content.Height * _startScale);
+                var originY = (e.ScaleOrigin.Y - deltaY) * deltaHeight;
+
+                var targetX = _xOffset - (originX * Content.Width) * (targetScale - _startScale);
+                var targetY = _yOffset - (originY * Content.Height) * (targetScale - _startScale);
+
+                Content.TranslationX = Clamp(targetX, -GetMaxTranslationX(targetScale), GetMaxTranslationX(targetScale));
+                Content.TranslationY = Clamp(targetY, -GetMaxTranslationY(targetScale), GetMaxTranslationY(targetScale));
+                Content.Scale = targetScale;
+
+                _currentScale = targetScale;
+                break;
+            case GestureStatus.Completed:
+                _xOffset = Content.TranslationX;
+                _yOffset = Content.TranslationY;
+                break;
+        }
+    }
+
+    private void OnPanUpdated(object? sender, PanUpdatedEventArgs e)
+    {
+        if (Content == null)
+        {
+            return;
+        }
+
+        switch (e.StatusType)
+        {
+            case GestureStatus.Running:
+                if (_currentScale <= 1)
+                {
+                    return;
+                }
+
+                var newX = _xOffset + e.TotalX;
+                var newY = _yOffset + e.TotalY;
+
+                Content.TranslationX = Clamp(newX, -GetMaxTranslationX(_currentScale), GetMaxTranslationX(_currentScale));
+                Content.TranslationY = Clamp(newY, -GetMaxTranslationY(_currentScale), GetMaxTranslationY(_currentScale));
+                break;
+            case GestureStatus.Completed:
+                _xOffset = Content.TranslationX;
+                _yOffset = Content.TranslationY;
+                break;
+        }
+    }
+
+    private double GetMaxTranslationX(double scale)
+    {
+        if (Content == null || Width <= 0)
+        {
+            return 0;
+        }
+
+        var scaledWidth = Content.Width * scale;
+        var maxTranslate = (scaledWidth - Width) / 2;
+        return Math.Max(0, maxTranslate);
+    }
+
+    private double GetMaxTranslationY(double scale)
+    {
+        if (Content == null || Height <= 0)
+        {
+            return 0;
+        }
+
+        var scaledHeight = Content.Height * scale;
+        var maxTranslate = (scaledHeight - Height) / 2;
+        return Math.Max(0, maxTranslate);
+    }
+
+    private static double Clamp(double value, double min, double max)
+    {
+        if (value < min)
+        {
+            return min;
+        }
+
+        if (value > max)
+        {
+            return max;
+        }
+
+        return value;
+    }
+}

--- a/MLScoreSheetCounter/MainPage.xaml
+++ b/MLScoreSheetCounter/MainPage.xaml
@@ -1,24 +1,59 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:MLScoreSheetCounter.Controls"
              x:Class="MLScoreSheetCounter.MainPage">
-    
-    <VerticalStackLayout Padding="16" Spacing="12">
-        <Button x:Name="PickPhotoButton" Text="Vybrat fotku z galerie" Clicked="OnPickPhoto"/>
-        <Button x:Name="TakePhotoButton" Text="Vyfotit" Clicked="OnTakePhoto"/>
 
-        <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
-            <CheckBox x:Name="OverlayCheckBox" IsChecked="True"/>
-            <Label Text="Zobrazit zvýraznění" VerticalTextAlignment="Center"/>
+    <Grid Padding="16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <VerticalStackLayout Grid.Row="0" Spacing="8">
+            <Button x:Name="PickPhotoButton" Text="Vybrat fotku z galerie" Clicked="OnPickPhoto" />
+            <Button x:Name="TakePhotoButton" Text="Vyfotit" Clicked="OnTakePhoto" />
+        </VerticalStackLayout>
+
+        <HorizontalStackLayout Grid.Row="1" Spacing="8" VerticalOptions="Center">
+            <CheckBox x:Name="OverlayCheckBox" IsChecked="True" />
+            <Label Text="Zobrazit zvýraznění" VerticalTextAlignment="Center" />
         </HorizontalStackLayout>
 
-        <Label x:Name="ResultLabel" Text="TOTAL = ?" FontSize="18" />
+        <Label x:Name="ResultLabel"
+               Grid.Row="2"
+               Text="TOTAL = ?"
+               FontSize="18"
+               FontAttributes="Bold" />
 
-        <HorizontalStackLayout x:Name="ProcessingContainer" IsVisible="False" Spacing="8" VerticalOptions="Center">
-            <ActivityIndicator x:Name="ProcessingIndicator" IsRunning="False" VerticalOptions="Center"/>
-            <Label x:Name="ProcessingLabel" Text="Probíhá zpracování..." VerticalTextAlignment="Center"/>
+        <HorizontalStackLayout x:Name="ProcessingContainer"
+                                Grid.Row="3"
+                                IsVisible="False"
+                                Spacing="8"
+                                VerticalOptions="Center">
+            <ActivityIndicator x:Name="ProcessingIndicator" IsRunning="False" VerticalOptions="Center" />
+            <Label x:Name="ProcessingLabel" Text="Probíhá zpracování..." VerticalTextAlignment="Center" />
         </HorizontalStackLayout>
 
-        <Image x:Name="Preview" Aspect="AspectFit" HeightRequest="380" />
-    </VerticalStackLayout>
+        <controls:PinchToZoomContainer x:Name="PreviewContainer"
+                                       Grid.Row="4"
+                                       BackgroundColor="#111"
+                                       VerticalOptions="Fill"
+                                       HorizontalOptions="Fill">
+            <Image x:Name="Preview"
+                   Aspect="AspectFit"
+                   VerticalOptions="Center"
+                   HorizontalOptions="Center" />
+        </controls:PinchToZoomContainer>
+
+        <Button x:Name="SaveToGalleryButton"
+                Grid.Row="5"
+                Text="Uložit do galerie"
+                IsEnabled="False"
+                Clicked="OnSaveToGalleryClicked" />
+    </Grid>
 </ContentPage>

--- a/MLScoreSheetCounter/MauiProgram.cs
+++ b/MLScoreSheetCounter/MauiProgram.cs
@@ -15,11 +15,15 @@ namespace MLScoreSheetCounter
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
 
+            builder.Services.AddSingleton<Services.IGallerySaver, Services.GallerySaver>();
+
 #if DEBUG
     		builder.Logging.AddDebug();
 #endif
 
-            return builder.Build();
+            var app = builder.Build();
+            ServiceHelper.Initialize(app.Services);
+            return app;
         }
     }
 }

--- a/MLScoreSheetCounter/Platforms/Android/AndroidManifest.xml
+++ b/MLScoreSheetCounter/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+        <uses-permission android:name="android.permission.INTERNET" />
+        <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+        <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 </manifest>

--- a/MLScoreSheetCounter/Platforms/Android/GallerySaver.cs
+++ b/MLScoreSheetCounter/Platforms/Android/GallerySaver.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Media;
+using Android.OS;
+using Android.Provider;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Storage;
+using Environment = Android.OS.Environment;
+
+namespace MLScoreSheetCounter.Services;
+
+public partial class GallerySaver : IGallerySaver
+{
+    private const string AlbumName = "MLScoreSheet";
+
+    public async Task SaveImageAsync(string filePath, string fileName, CancellationToken cancellationToken = default)
+    {
+        var context = Platform.CurrentActivity ?? Platform.AppContext;
+        var mimeType = GetMimeType(fileName);
+
+        if (Build.VERSION.SdkInt >= BuildVersionCodes.Q)
+        {
+            await SaveWithMediaStoreAsync(context, filePath, fileName, mimeType, cancellationToken);
+        }
+        else
+        {
+            await SaveLegacyAsync(context, filePath, fileName, cancellationToken);
+        }
+    }
+
+    private static async Task SaveWithMediaStoreAsync(Context context, string filePath, string fileName, string mimeType, CancellationToken cancellationToken)
+    {
+        var values = new ContentValues();
+        values.Put(MediaStore.MediaColumns.DisplayName, fileName);
+        values.Put(MediaStore.MediaColumns.MimeType, mimeType);
+        values.Put(MediaStore.MediaColumns.RelativePath, $"{Environment.DirectoryPictures}/{AlbumName}");
+        values.Put(MediaStore.MediaColumns.IsPending, 1);
+
+        var resolver = context.ContentResolver;
+        var uri = resolver.Insert(MediaStore.Images.Media.ExternalContentUri, values);
+        if (uri == null)
+        {
+            throw new InvalidOperationException("Nepodařilo se vytvořit položku v galerii.");
+        }
+
+        await using (var input = File.OpenRead(filePath))
+        await using (var output = resolver.OpenOutputStream(uri) ?? throw new InvalidOperationException("Nelze otevřít výstupní proud."))
+        {
+            await input.CopyToAsync(output, cancellationToken);
+        }
+
+        values.Put(MediaStore.MediaColumns.IsPending, 0);
+        resolver.Update(uri, values, null, null);
+    }
+
+    private static async Task SaveLegacyAsync(Context context, string filePath, string fileName, CancellationToken cancellationToken)
+    {
+        var picturesPath = Environment.GetExternalStoragePublicDirectory(Environment.DirectoryPictures)?.AbsolutePath
+            ?? FileSystem.Current.CacheDirectory;
+        var directory = Path.Combine(picturesPath, AlbumName);
+        Directory.CreateDirectory(directory);
+
+        var destinationPath = Path.Combine(directory, fileName);
+        await using (var input = File.OpenRead(filePath))
+        await using (var output = File.Create(destinationPath))
+        {
+            await input.CopyToAsync(output, cancellationToken);
+        }
+
+        MediaScannerConnection.ScanFile(context, new[] { destinationPath }, null, null);
+    }
+
+    private static string GetMimeType(string fileName)
+    {
+        var extension = Path.GetExtension(fileName).ToLowerInvariant();
+        return extension switch
+        {
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            _ => "image/jpeg"
+        };
+    }
+}

--- a/MLScoreSheetCounter/Platforms/iOS/GallerySaver.cs
+++ b/MLScoreSheetCounter/Platforms/iOS/GallerySaver.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundation;
+using MLScoreSheetCounter.Services;
+using Photos;
+
+namespace MLScoreSheetCounter.Services;
+
+public partial class GallerySaver : IGallerySaver
+{
+    public async Task SaveImageAsync(string filePath, string fileName, CancellationToken cancellationToken = default)
+    {
+        var status = PHPhotoLibrary.AuthorizationStatusForAccessLevel(PHAccessLevel.AddOnly);
+        if (status == PHAuthorizationStatus.NotDetermined)
+        {
+            status = await PHPhotoLibrary.RequestAuthorizationAsync(PHAccessLevel.AddOnly);
+        }
+
+        if (status is not (PHAuthorizationStatus.Authorized or PHAuthorizationStatus.Limited))
+        {
+            throw new InvalidOperationException("Aplikace nemá oprávnění ukládat do fotogalerie.");
+        }
+
+        var url = NSUrl.FromFilename(filePath);
+        if (url == null)
+        {
+            throw new InvalidOperationException("Nelze otevřít soubor pro uložení.");
+        }
+
+        await PHPhotoLibrary.SharedPhotoLibrary.PerformChangesAsync(() =>
+        {
+            var request = PHAssetCreationRequest.CreationRequestForAsset();
+            request.AddResource(PHAssetResourceType.Photo, url, new PHAssetResourceCreationOptions());
+        });
+    }
+}

--- a/MLScoreSheetCounter/Platforms/iOS/Info.plist
+++ b/MLScoreSheetCounter/Platforms/iOS/Info.plist
@@ -19,14 +19,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>XSAppIconAssets</key>
-	<string>Assets.xcassets/appicon.appiconset</string>
+        <key>UISupportedInterfaceOrientations~ipad</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+                <string>UIInterfaceOrientationPortraitUpsideDown</string>
+                <string>UIInterfaceOrientationLandscapeLeft</string>
+                <string>UIInterfaceOrientationLandscapeRight</string>
+        </array>
+        <key>XSAppIconAssets</key>
+        <string>Assets.xcassets/appicon.appiconset</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>Aplikace potřebuje přístup k fotkám kvůli uložení výsledného obrázku.</string>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>Aplikace potřebuje oprávnění pro přidání obrázků do galerie.</string>
 </dict>
 </plist>

--- a/MLScoreSheetCounter/ServiceHelper.cs
+++ b/MLScoreSheetCounter/ServiceHelper.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MLScoreSheetCounter;
+
+public static class ServiceHelper
+{
+    private static IServiceProvider? _services;
+
+    public static void Initialize(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    public static T GetRequiredService<T>() where T : notnull
+    {
+        if (_services == null)
+        {
+            throw new InvalidOperationException("Služby nejsou inicializovány.");
+        }
+
+        return _services.GetRequiredService<T>();
+    }
+}

--- a/MLScoreSheetCounter/Services/GallerySaver.cs
+++ b/MLScoreSheetCounter/Services/GallerySaver.cs
@@ -1,0 +1,5 @@
+namespace MLScoreSheetCounter.Services;
+
+public partial class GallerySaver : IGallerySaver
+{
+}

--- a/MLScoreSheetCounter/Services/IGallerySaver.cs
+++ b/MLScoreSheetCounter/Services/IGallerySaver.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MLScoreSheetCounter.Services;
+
+public interface IGallerySaver
+{
+    Task SaveImageAsync(string filePath, string fileName, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
## Summary
- redesign the main page layout with a zoomable preview surface and an action to save the processed image
- add gallery saver services for Android and iOS together with the required permissions/prompts
- register the gallery saver through dependency injection and expose a helper for resolving it on the page
- fix the Android gallery saver to use the MAUI Platform context instead of the unavailable Application.Context

## Testing
- Unable to run `dotnet build -t:Build -f net9.0-android` (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4ea458f68832cb0796b1759ac9685