### PR TITLE
Add configurable thresholds and improve zoom

### DIFF
--- a/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
+++ b/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
@@ -5,6 +5,7 @@ namespace MLScoreSheetCounter.Controls;
 
 public class PinchToZoomContainer : ContentView
 {
+    private const double MaxZoomScale = 20;
     private double _currentScale = 1;
     private double _startScale = 1;
     private double _xOffset;
@@ -57,7 +58,7 @@ public class PinchToZoomContainer : ContentView
                 Content.AnchorY = 0;
                 break;
             case GestureStatus.Running:
-                var targetScale = Math.Clamp(_startScale * e.Scale, 1, 6);
+                var targetScale = Math.Clamp(_startScale * e.Scale, 1, MaxZoomScale);
 
                 var renderedX = Content.X + _xOffset;
                 var deltaX = renderedX / Width;

--- a/MLScoreSheetCounter/MainPage.xaml
+++ b/MLScoreSheetCounter/MainPage.xaml
@@ -10,6 +10,8 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -24,14 +26,44 @@
             <Label Text="Zobrazit zvýraznění" VerticalTextAlignment="Center" />
         </HorizontalStackLayout>
 
+        <HorizontalStackLayout Grid.Row="2" Spacing="8" VerticalOptions="Center">
+            <Label Text="Práh výpočtu" VerticalTextAlignment="Center" />
+            <Slider x:Name="CalculationTresholdSlider"
+                    Minimum="0"
+                    Maximum="1"
+                    Value="0.3"
+                    HorizontalOptions="FillAndExpand"
+                    ValueChanged="OnCalculationThresholdChanged" />
+            <Label x:Name="CalculationThresholdValueLabel"
+                   Text="0.30"
+                   WidthRequest="50"
+                   HorizontalTextAlignment="End"
+                   VerticalTextAlignment="Center" />
+        </HorizontalStackLayout>
+
+        <HorizontalStackLayout Grid.Row="3" Spacing="8" VerticalOptions="Center">
+            <Label Text="Práh viditelnosti" VerticalTextAlignment="Center" />
+            <Slider x:Name="VisibilityTresholdSlider"
+                    Minimum="0"
+                    Maximum="1"
+                    Value="0.3"
+                    HorizontalOptions="FillAndExpand"
+                    ValueChanged="OnVisibilityThresholdChanged" />
+            <Label x:Name="VisibilityThresholdValueLabel"
+                   Text="0.30"
+                   WidthRequest="50"
+                   HorizontalTextAlignment="End"
+                   VerticalTextAlignment="Center" />
+        </HorizontalStackLayout>
+
         <Label x:Name="ResultLabel"
-               Grid.Row="2"
+               Grid.Row="4"
                Text="TOTAL = ?"
                FontSize="18"
                FontAttributes="Bold" />
 
         <HorizontalStackLayout x:Name="ProcessingContainer"
-                                Grid.Row="3"
+                                Grid.Row="5"
                                 IsVisible="False"
                                 Spacing="8"
                                 VerticalOptions="Center">
@@ -40,7 +72,7 @@
         </HorizontalStackLayout>
 
         <controls:PinchToZoomContainer x:Name="PreviewContainer"
-                                       Grid.Row="4"
+                                       Grid.Row="6"
                                        BackgroundColor="#111"
                                        VerticalOptions="Fill"
                                        HorizontalOptions="Fill">
@@ -51,7 +83,7 @@
         </controls:PinchToZoomContainer>
 
         <Button x:Name="SaveToGalleryButton"
-                Grid.Row="5"
+                Grid.Row="7"
                 Text="Uložit do galerie"
                 IsEnabled="False"
                 Clicked="OnSaveToGalleryClicked" />

--- a/MLScoreSheetCounter/SheetScoreEngine.cs
+++ b/MLScoreSheetCounter/SheetScoreEngine.cs
@@ -70,7 +70,8 @@ public static class SheetScoreEngine
         float autoMin = 0.25f,
         float autoMax = 0.65f,
         float padFrac = 0.08f,
-        float openFrac = 0.03f)
+        float openFrac = 0.03f,
+        float overlayVisibilityThreshold = 0.30f)
     {
         //using var photo = SKBitmap.Decode(photoStream) ?? throw new InvalidOperationException("Nelze dekódovat foto.");
         using var photo = DecodeLandscapePhoto(photoStream);
@@ -101,7 +102,8 @@ public static class SheetScoreEngine
             tpl.Rects,
             pList,
             res.WinnerIndices,
-            groups
+            groups,
+            overlayVisibilityThreshold
         );
 
         // ... návratová hodnota:
@@ -1058,7 +1060,8 @@ public static class SheetScoreEngine
         List<SKRectI> rects,
         float[] pList,
         IList<int> winnerIndices,
-        List<Group> groups)
+        List<Group> groups,
+        float visibilityThreshold)
     {
         // Připrav mapu slotu 0..5 pro každý index (kvůli číslici v boxu)
         var slotByIndex = Enumerable.Repeat(-1, rects.Count).ToArray();
@@ -1189,8 +1192,8 @@ public static class SheetScoreEngine
                 // popisky: index, % fill, slot 0..5
                 string idxLabel = $"#{i}";
                 string fillLabel = $"{Math.Round(pList[i] * 100)}%";
-                // ukazovat jen kdyz {Math.Round(pList[i] * 100)} je vic nez 30%?
-                bool showFill = pList[i] > 0.30f;
+                // ukazovat jen kdyz hodnota prekroci viditelnostni prah
+                bool showFill = pList[i] > visibilityThreshold;
 
 
                 string slotLabel = slotByIndex[i] >= 0 ? slotByIndex[i].ToString() : "?";


### PR DESCRIPTION
## Summary
- add sliders on the main page to configure calculation and visibility thresholds and display their current values
- update score processing to respect the selected thresholds, including overlay label visibility
- raise the pinch-to-zoom container limit to allow much higher magnification

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e50f597a08832ca3ffbab7fd2e320d