### PR TITLE
Fix pinch zoom anchor handling

### DIFF
--- a/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
+++ b/MLScoreSheetCounter/Controls/PinchToZoomContainer.cs
@@ -54,10 +54,15 @@ public class PinchToZoomContainer : ContentView
         {
             case GestureStatus.Started:
                 _startScale = Content.Scale;
-                Content.AnchorX = 0;
-                Content.AnchorY = 0;
+                Content.AnchorX = e.ScaleOrigin.X;
+                Content.AnchorY = e.ScaleOrigin.Y;
                 break;
             case GestureStatus.Running:
+                if (Width <= 0 || Height <= 0 || Content.Width <= 0 || Content.Height <= 0)
+                {
+                    return;
+                }
+
                 var targetScale = Math.Clamp(_startScale * e.Scale, 1, MaxZoomScale);
 
                 var renderedX = Content.X + _xOffset;
@@ -82,6 +87,9 @@ public class PinchToZoomContainer : ContentView
             case GestureStatus.Completed:
                 _xOffset = Content.TranslationX;
                 _yOffset = Content.TranslationY;
+                _currentScale = Content.Scale;
+                Content.AnchorX = 0.5;
+                Content.AnchorY = 0.5;
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- align the pinch gesture anchor with the touch origin so the image keeps its zoomed size
- skip pinch calculations until both the container and image have measurable dimensions
- restore the content anchor after a pinch completes while keeping the updated scale and offsets

## Testing
- `dotnet build MLScoreSheetCounter/MLScoreSheetCounter.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5148b41f8832c96e105020faf9988