### PR TITLE
Design scoresheet themed app icon

### DIFF
--- a/MLScoreSheetCounter/Resources/AppIcon/appicon.svg
+++ b/MLScoreSheetCounter/Resources/AppIcon/appicon.svg
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#071631" />
+      <stop offset="50%" stop-color="#123b7a" />
+      <stop offset="100%" stop-color="#1b61f2" />
+    </linearGradient>
+    <linearGradient id="gridGlow" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.35)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </linearGradient>
+    <pattern id="diagonalStripes" patternUnits="userSpaceOnUse" width="32" height="32" patternTransform="rotate(45)">
+      <rect x="0" y="0" width="32" height="32" fill="rgba(255,255,255,0.04)" />
+      <rect x="0" y="0" width="16" height="32" fill="rgba(255,255,255,0.05)" />
+    </pattern>
+  </defs>
+  <rect width="456" height="456" rx="96" fill="url(#bgGradient)" />
+  <rect x="48" y="48" width="360" height="360" rx="80" fill="url(#diagonalStripes)" opacity="0.65" />
+  <rect x="48" y="48" width="360" height="360" rx="80" fill="none" stroke="url(#gridGlow)" stroke-width="4" />
 </svg>

--- a/MLScoreSheetCounter/Resources/AppIcon/appiconfg.svg
+++ b/MLScoreSheetCounter/Resources/AppIcon/appiconfg.svg
@@ -1,8 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="scoreboardBody" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#102744" />
+      <stop offset="100%" stop-color="#1a3a66" />
+    </linearGradient>
+    <linearGradient id="scoreDigits" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#9df3ff" />
+      <stop offset="100%" stop-color="#5fe1ff" />
+    </linearGradient>
+    <linearGradient id="lensRing" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffdd6f" />
+      <stop offset="100%" stop-color="#ff8a3d" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(76 104)">
+    <rect x="0" y="0" width="304" height="248" rx="36" fill="url(#scoreboardBody)" stroke="#3b74f2" stroke-width="8" />
+    <g transform="translate(28 36)">
+      <rect x="0" y="0" width="248" height="176" rx="24" fill="#0d1c33" stroke="#1f4fbf" stroke-width="4" />
+      <line x1="124" y1="16" x2="124" y2="160" stroke="#1f4fbf" stroke-width="3" stroke-dasharray="8 12" opacity="0.65" />
+      <g transform="translate(24 20)" fill="url(#scoreDigits)">
+        <path d="M38 0h-32c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h20c6.6 0 12 5.4 12 12v36c0 6.6-5.4 12-12 12h-32" stroke="#9df3ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+        <path d="M94 0h-36v112h36c6.6 0 12-5.4 12-12V12c0-6.6-5.4-12-12-12z" stroke="#9df3ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+      </g>
+      <g transform="translate(148 20)" fill="url(#scoreDigits)">
+        <path d="M12 0h44c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12V12C0 5.4 5.4 0 12 0z" stroke="#9df3ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+        <path d="M0 112h68" stroke="#9df3ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M12 56h44c6.6 0 12 5.4 12 12v32c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12V68c0-6.6 5.4-12 12-12z" stroke="#9df3ff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+      </g>
+      <circle cx="124" cy="88" r="18" fill="#1f4fbf" opacity="0.55" />
+    </g>
+    <g transform="translate(212 160)">
+      <circle cx="80" cy="80" r="64" fill="rgba(15,34,60,0.9)" stroke="url(#lensRing)" stroke-width="10" />
+      <circle cx="80" cy="80" r="36" fill="none" stroke="#8fffd2" stroke-width="6" />
+      <line x1="80" y1="34" x2="80" y2="126" stroke="#8fffd2" stroke-width="6" stroke-linecap="round" opacity="0.85" />
+      <line x1="34" y1="80" x2="126" y2="80" stroke="#8fffd2" stroke-width="6" stroke-linecap="round" opacity="0.85" />
+      <circle cx="80" cy="80" r="12" fill="#8fffd2" opacity="0.65" />
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the app icon background with a dark-to-electric blue gradient and subtle diagonal texture for depth
- draw a foreground scoreboard with dual scores and a detection lens motif to emphasize score recognition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61f985448832ca2173d88d6533418