### PR TITLE
Show capture guidance before preview and translate UI text

### DIFF
--- a/MLScoreSheetCounter/MainPage.xaml
+++ b/MLScoreSheetCounter/MainPage.xaml
@@ -150,18 +150,32 @@
         </Grid>
 
         <!-- Row 6: Preview (fills the remaining space thanks to RowDefinition "*") -->
-        <controls:PanPinchContainer x:Name="PreviewContainer"
-                                    Grid.Row="6"
-                                    BackgroundColor="#111"
-                                    VerticalOptions="Fill"
-                                    HorizontalOptions="Fill">
-            <Image x:Name="Preview"
-                   Aspect="AspectFit"
-                   VerticalOptions="Center"
-                   HorizontalOptions="Center"
-                   AutomationProperties.IsInAccessibleTree="True"
-                   SemanticProperties.Description="Preview of the selected photo with pan and zoom" />
-        </controls:PanPinchContainer>
+        <Grid Grid.Row="6">
+            <ContentView x:Name="PreviewPlaceholder"
+                         Padding="24"
+                         BackgroundColor="#111"
+                         HorizontalOptions="Fill"
+                         VerticalOptions="Fill">
+                <Label Text="Place the score sheet on a flat, well-lit surface. Hold the camera directly above it so the entire sheet is visible and free of shadows."
+                       TextColor="#fff"
+                       FontSize="16"
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center" />
+            </ContentView>
+
+            <controls:PanPinchContainer x:Name="PreviewContainer"
+                                        IsVisible="False"
+                                        BackgroundColor="#111"
+                                        VerticalOptions="Fill"
+                                        HorizontalOptions="Fill">
+                <Image x:Name="Preview"
+                       Aspect="AspectFit"
+                       VerticalOptions="Center"
+                       HorizontalOptions="Center"
+                       AutomationProperties.IsInAccessibleTree="True"
+                       SemanticProperties.Description="Preview of the selected photo with pan and zoom" />
+            </controls:PanPinchContainer>
+        </Grid>
 
         <!-- Row 7: Save -->
         <Button x:Name="SaveToGalleryButton"

--- a/MLScoreSheetCounter/Platforms/Android/GallerySaver.cs
+++ b/MLScoreSheetCounter/Platforms/Android/GallerySaver.cs
@@ -43,11 +43,11 @@ public partial class GallerySaver : IGallerySaver
         var uri = resolver.Insert(MediaStore.Images.Media.ExternalContentUri, values);
         if (uri == null)
         {
-            throw new InvalidOperationException("Nepodařilo se vytvořit položku v galerii.");
+            throw new InvalidOperationException("Failed to create a gallery entry.");
         }
 
         await using (var input = File.OpenRead(filePath))
-        await using (var output = resolver.OpenOutputStream(uri) ?? throw new InvalidOperationException("Nelze otevřít výstupní proud."))
+        await using (var output = resolver.OpenOutputStream(uri) ?? throw new InvalidOperationException("Unable to open the output stream."))
         {
             await input.CopyToAsync(output, cancellationToken);
         }

--- a/MLScoreSheetCounter/Platforms/iOS/GallerySaver.cs
+++ b/MLScoreSheetCounter/Platforms/iOS/GallerySaver.cs
@@ -20,13 +20,13 @@ public partial class GallerySaver : IGallerySaver
 
         if (status is not (PHAuthorizationStatus.Authorized or PHAuthorizationStatus.Limited))
         {
-            throw new InvalidOperationException("Aplikace nemá oprávnění ukládat do fotogalerie.");
+            throw new InvalidOperationException("The app does not have permission to save to the photo library.");
         }
 
         var url = NSUrl.FromFilename(filePath);
         if (url == null)
         {
-            throw new InvalidOperationException("Nelze otevřít soubor pro uložení.");
+            throw new InvalidOperationException("Unable to open the file for saving.");
         }
 
 

--- a/MLScoreSheetCounter/Platforms/iOS/Info.plist
+++ b/MLScoreSheetCounter/Platforms/iOS/Info.plist
@@ -14,11 +14,11 @@
 		<string>arm64</string>
 	</array>
   <key>NSCameraUsageDescription</key>
-  <string>Aplikace potřebuje přístup ke kameře pro focení výsledkových listů.</string>
+  <string>The app needs camera access to capture score sheets.</string>
   <key>NSPhotoLibraryUsageDescription</key>
-  <string>Aplikace potřebuje číst fotky pro jejich výběr a zobrazení.</string>
+  <string>The app needs to read photos so you can pick and display them.</string>
   <key>NSPhotoLibraryAddUsageDescription</key>
-  <string>Aplikace potřebuje ukládat snímky do vaší knihovny fotek.</string>
+  <string>The app needs to save images to your photo library.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -35,8 +35,8 @@
         <key>XSAppIconAssets</key>
         <string>Assets.xcassets/appicon.appiconset</string>
         <key>NSPhotoLibraryUsageDescription</key>
-        <string>Aplikace potřebuje přístup k fotkám kvůli uložení výsledného obrázku.</string>
+        <string>The app needs access to photos to store the processed image.</string>
         <key>NSPhotoLibraryAddUsageDescription</key>
-        <string>Aplikace potřebuje oprávnění pro přidání obrázků do galerie.</string>
+        <string>The app needs permission to add images to the gallery.</string>
 </dict>
 </plist>

--- a/MLScoreSheetCounter/Platforms/iOS/IosPermissions.cs
+++ b/MLScoreSheetCounter/Platforms/iOS/IosPermissions.cs
@@ -34,7 +34,7 @@ namespace MLScoreSheetCounter.Platforms.iOS
         private static void ThrowCameraDenied()
         {
             throw new UnauthorizedAccessException(
-                "Přístup ke kameře byl odepřen. Povolit lze v Nastavení → Soukromí → Fotoaparát.");
+                "Camera access was denied. You can allow it in Settings → Privacy → Camera.");
         }
 
         // PHOTOS (READ/WRITE) -----------------------------------------------------
@@ -46,10 +46,10 @@ namespace MLScoreSheetCounter.Platforms.iOS
                 status = await RequestPhotosAsync(PHAccessLevel.ReadWrite);
             }
 
-            // iOS může vrátit "Limited" – to pro čtení stačí
+            // iOS can return "Limited" – that is sufficient for reading
             if (status != PHAuthorizationStatus.Authorized && status != PHAuthorizationStatus.Limited)
             {
-                ThrowPhotosDenied("čtení z knihovny fotek");
+                ThrowPhotosDenied("reading from the photo library");
             }
         }
 
@@ -63,7 +63,7 @@ namespace MLScoreSheetCounter.Platforms.iOS
 
             if (status != PHAuthorizationStatus.Authorized)
             {
-                ThrowPhotosDenied("ukládání do knihovny fotek");
+                ThrowPhotosDenied("saving to the photo library");
             }
         }
 
@@ -77,10 +77,10 @@ namespace MLScoreSheetCounter.Platforms.iOS
         private static void ThrowPhotosDenied(string what)
         {
             throw new UnauthorizedAccessException(
-                $"Oprávnění pro {what} bylo odepřeno. Povolit lze v Nastavení → Soukromí → Fotky.");
+                $"Permission for {what} was denied. You can allow it in Settings → Privacy → Photos.");
         }
 
-        // Volitelné: otevření nastavení appky
+        // Optional: open the app settings
         public static void OpenAppSettings()
         {
             var url = new NSUrl(UIApplication.OpenSettingsUrlString);

--- a/MLScoreSheetCounter/Platforms/iOS/PhotoSaver.cs
+++ b/MLScoreSheetCounter/Platforms/iOS/PhotoSaver.cs
@@ -8,11 +8,11 @@ using UIKit;
 namespace MLScoreSheetCounter.Platforms.iOS
 {
     /// <summary>
-    /// Helpery pro ukládání fotek do Fotek (Photos) s podporou async.
+    /// Helpers for saving photos to the Photos library with async support.
     /// </summary>
     public static class PhotoSaver
     {
-        // --- 1) Async wrapper pro PHPhotoLibrary.PerformChanges ---
+        // --- 1) Async wrapper for PHPhotoLibrary.PerformChanges ---
         public static Task<bool> PerformChangesAsync(this PHPhotoLibrary library, Action changeHandler)
         {
             if (library is null) throw new ArgumentNullException(nameof(library));
@@ -37,7 +37,7 @@ namespace MLScoreSheetCounter.Platforms.iOS
             return tcs.Task;
         }
 
-        // --- 2) Zajištění oprávnění: iOS 14+ používá AccessLevel ---
+        // --- 2) Ensure permissions: iOS 14+ uses AccessLevel ---
         public static async Task EnsureAddOnlyAuthorizationAsync()
         {
             var status = PHPhotoLibrary.GetAuthorizationStatus(PHAccessLevel.AddOnly);
@@ -46,7 +46,7 @@ namespace MLScoreSheetCounter.Platforms.iOS
 
             status = await RequestAddOnlyAuthorizationAsync();
             if (status != PHAuthorizationStatus.Authorized)
-                throw new UnauthorizedAccessException("Přístup k ukládání do Fotek nebyl povolen.");
+                throw new UnauthorizedAccessException("Saving to the Photos library was not authorized.");
         }
 
         private static Task<PHAuthorizationStatus> RequestAddOnlyAuthorizationAsync()
@@ -56,14 +56,14 @@ namespace MLScoreSheetCounter.Platforms.iOS
             return tcs.Task;
         }
 
-        // --- 3) Uložení fotky ze souboru (NSUrl) ---
+        // --- 3) Save a photo from a file (NSUrl) ---
         /// <summary>
-        /// Uloží fotku (soubor) do knihovny Fotek.
+        /// Saves a photo (file) to the Photos library.
         /// </summary>
-        /// <param name="fileUrl">NSUrl na lokální soubor (např. v /tmp nebo /Documents).</param>
+        /// <param name="fileUrl">NSUrl to a local file (for example in /tmp or /Documents).</param>
         /// <param name="shouldMoveFile">
-        /// true = soubor se po přidání přesune (musí být v místě, kam má app právo zapisovat/měnit),
-        /// false = zůstane a data se zkopírují.
+        /// true = move the file after adding (the app must have permission to modify the location),
+        /// false = keep the file in place and copy the data.
         /// </param>
         public static async Task SavePhotoFileAsync(NSUrl fileUrl, bool shouldMoveFile = false)
         {
@@ -83,7 +83,7 @@ namespace MLScoreSheetCounter.Platforms.iOS
             });
         }
 
-        // --- 4) Uložení fotky z paměti (NSData/byte[]/UIImage) ---
+        // --- 4) Save a photo from memory (NSData/byte[]/UIImage) ---
         public static async Task SavePhotoDataAsync(NSData data)
         {
             if (data is null) throw new ArgumentNullException(nameof(data));
@@ -105,12 +105,12 @@ namespace MLScoreSheetCounter.Platforms.iOS
         {
             if (image is null) throw new ArgumentNullException(nameof(image));
 
-            // Ulož jako JPEG (můžeš změnit na PNG: image.AsPNG())
+            // Save as JPEG (switch to PNG with image.AsPNG() if needed)
             using var data = image.AsJPEG(jpegQuality);
             await SavePhotoDataAsync(data);
         }
 
-        // --- 5) Pomocník: uloží stream do /tmp a pak do Fotek ---
+        // --- 5) Helper: save a stream to /tmp and then to Photos ---
         public static async Task SaveStreamAsync(Stream stream, string fileName = "photo.jpg", bool shouldMoveFile = true)
         {
             if (stream is null) throw new ArgumentNullException(nameof(stream));

--- a/MLScoreSheetCounter/ServiceHelper.cs
+++ b/MLScoreSheetCounter/ServiceHelper.cs
@@ -16,7 +16,7 @@ public static class ServiceHelper
     {
         if (_services == null)
         {
-            throw new InvalidOperationException("Služby nejsou inicializovány.");
+            throw new InvalidOperationException("Services have not been initialized.");
         }
 
         return _services.GetRequiredService<T>();


### PR DESCRIPTION
## Summary
- display capture instructions in the preview area until a photo overlay is loaded
- toggle the preview container visibility from code-behind when images are assigned
- translate remaining Czech runtime strings and platform messages into English

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e65b6029d0832c820e910f72c84331