### PR TITLE
Add integration tests for score computation

### DIFF
--- a/MLScoreSheet.Core.Tests/MLScoreSheet.Core.Tests.csproj
+++ b/MLScoreSheet.Core.Tests/MLScoreSheet.Core.Tests.csproj
@@ -20,5 +20,6 @@
     <None Include="..\MLScoreSheetCounter\Resources\Raw\boxes_rects.json" Link="Assets\boxes_rects.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\MLScoreSheetCounter\Resources\Raw\ocrscoresheetfiducials.png" Link="Assets\ocrscoresheetfiducials.png" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\MLScoreSheetCounter\Resources\Raw\best.onnx" Link="Assets\best.onnx" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\MLScoreSheet.ConsoleApp\photo2.jpeg" Link="Assets\photo2.jpeg" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/MLScoreSheet.Core.Tests/ScoreSelector3x2Tests.cs
+++ b/MLScoreSheet.Core.Tests/ScoreSelector3x2Tests.cs
@@ -32,4 +32,41 @@ public class ScoreSelector3x2Tests
         Assert.Contains(1, result.WinnerIndices);
         Assert.Equal(1, result.WinnerIndices.Count);
     }
+
+    [Fact]
+    public void SumWinnerTakesAll_ReturnsZeroWhenCountsDiffer()
+    {
+        var rects = new List<SKRectI> { new(0, 0, 10, 10) };
+        var probs = new List<float>();
+
+        var result = ScoreSelector3x2.SumWinnerTakesAll(rects, probs, 0.4f);
+
+        Assert.Equal(0, result.Total);
+        Assert.Equal(0.4f, result.ThresholdUsed);
+        Assert.Empty(result.WinnerIndices);
+    }
+
+    [Fact]
+    public void SumWinnerTakesAll_RespectsGeometryWhenRectsUnordered()
+    {
+        var rects = new List<SKRectI>
+        {
+            new(0, 20, 10, 30), // bottom left
+            new(0, 0, 10, 10),  // top left
+            new(20, 20, 30, 30),
+            new(20, 0, 30, 10),
+            new(40, 20, 50, 30),
+            new(40, 0, 50, 10)
+        };
+
+        var probs = new List<float> { 0.95f, 0.1f, 0.96f, 0.7f, 0.7f, 0.85f };
+
+        var result = ScoreSelector3x2.SumWinnerTakesAll(rects, probs, 0.5f);
+
+        Assert.Equal(9, result.Total);
+        Assert.Contains(0, result.WinnerIndices); // bottom-left
+        Assert.Contains(2, result.WinnerIndices); // bottom-middle
+        Assert.Contains(5, result.WinnerIndices); // top-right
+        Assert.Equal(3, result.WinnerIndices.Count);
+    }
 }

--- a/MLScoreSheet.Core.Tests/SheetScoreEngineTests.cs
+++ b/MLScoreSheet.Core.Tests/SheetScoreEngineTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using MLScoreSheet.Core;
+using Xunit;
+
+public sealed class SheetScoreEngineTests
+{
+    private readonly TestResourceProvider _resourceProvider = new();
+
+    [Fact]
+    public async Task ComputeTotalScoreAsync_ReturnsExpectedScore_ForPhoto2()
+    {
+        var photoPath = TestResourceProvider.GetAssetPath("photo2.jpeg");
+        using var photoStream = File.OpenRead(photoPath);
+
+        var total = await SheetScoreEngine.ComputeTotalScoreAsync(
+            photoStream,
+            _resourceProvider,
+            fixedThreshold: 0.25f,
+            autoThreshold: false,
+            padFrac: 0.08f,
+            openFrac: 0.03f);
+
+        Assert.Equal(43, total);
+    }
+
+    [Fact]
+    public async Task ComputeTotalScoreWithOverlayAsync_ProducesOverlayAndThreshold_ForPhoto2()
+    {
+        var photoPath = TestResourceProvider.GetAssetPath("photo2.jpeg");
+        using var photoStream = File.OpenRead(photoPath);
+
+        await using var result = await SheetScoreEngine.ComputeTotalScoreWithOverlayAsync(
+            photoStream,
+            _resourceProvider,
+            fixedThreshold: 0.25f,
+            autoThreshold: false,
+            overlayVisibilityThreshold: 0.24f);
+
+        Assert.Equal(43, result.Total);
+        Assert.Equal(0.25f, result.ThresholdUsed, precision: 3);
+        Assert.NotNull(result.Overlay);
+        Assert.True(result.Overlay.Width > 0);
+        Assert.True(result.Overlay.Height > 0);
+    }
+
+    private sealed class TestResourceProvider : IResourceProvider
+    {
+        private readonly string _assetDirectory;
+
+        public TestResourceProvider()
+        {
+            _assetDirectory = Path.Combine(AppContext.BaseDirectory, "Assets");
+        }
+
+        public Task<Stream> OpenReadAsync(string logicalName)
+        {
+            var path = Path.Combine(_assetDirectory, logicalName);
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Asset '{logicalName}' not found at '{path}'.");
+            }
+
+            Stream stream = File.OpenRead(path);
+            return Task.FromResult(stream);
+        }
+
+        public static string GetAssetPath(string logicalName)
+        {
+            var baseDirectory = Path.Combine(AppContext.BaseDirectory, "Assets");
+            return Path.Combine(baseDirectory, logicalName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the photo2.jpeg asset to the test project so it is available at runtime
- create integration tests that exercise SheetScoreEngine with the real resources and expect a total of 43 points
- extend ScoreSelector3x2 unit coverage for mismatched inputs and unordered geometry scenarios

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e667c90658832c8fc794f734e39998